### PR TITLE
Feat/sync with s3 on startup

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -56,6 +56,7 @@ import { getSettings } from "./src/serverSettings/serverSettingsCache.js";
 import { Command, CommandContext } from "./src/command.js";
 import UploadToS3Handler from "./src/handlers/uploadToS3Handler.js";
 import DeleteFromS3Handler from "./src/handlers/deleteFromS3Handler.js";
+import { S3SynchronizationJob } from "./src/jobs/s3SynchronizationJob.js";
 
 tracingSdk().start();
 
@@ -164,10 +165,17 @@ if (soundboartConfig.s3Config) {
   const deleteFromS3Handler = new DeleteFromS3Handler(
     soundboartConfig.s3Config
   );
+
   soundBoartEventEmitter.registerHandler(
     deleteFromS3Event,
     deleteFromS3Handler
   );
+
+  const s3SynchronizationJob = new S3SynchronizationJob(
+    soundboartConfig.s3Config
+  );
+
+  await s3SynchronizationJob.run();
 }
 
 const getPrefix = async (message: Message) => {

--- a/src/handlers/uploadToS3Handler.ts
+++ b/src/handlers/uploadToS3Handler.ts
@@ -4,6 +4,7 @@ import ICommandHandler from "./commandHandler.js";
 import { Command } from "../command.js";
 import { PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
 import { Paths, fileOrDirectoryExists } from "../utils/fsHelpers.js";
+import { SoundObjectKey } from "../utils/s3.js";
 const fsAsync = fs.promises;
 
 export type UploadToS3HandlerParams = {
@@ -77,7 +78,7 @@ class UploadToS3Handler implements ICommandHandler<UploadToS3HandlerParams> {
   ): Promise<PutObjectCommand> {
     const fileContent = await fsAsync.readFile(localFilePath);
 
-    const key = `servers/${serverId}/sounds/${soundName}.mp3`;
+    const key = new SoundObjectKey(serverId, soundName).serialize();
 
     return new PutObjectCommand({
       Bucket: this._bucketName,

--- a/src/jobs/s3SynchronizationJob.ts
+++ b/src/jobs/s3SynchronizationJob.ts
@@ -1,0 +1,53 @@
+import { ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3";
+import { S3Config } from "../config.js";
+import fs from "fs";
+const fsAsync = fs.promises;
+
+export class S3SynchronizationJob {
+  private _s3Client: S3Client;
+  private _bucketName: string;
+
+  constructor(s3config: S3Config) {
+    this._bucketName = s3config.bucketName;
+
+    this._s3Client = new S3Client({
+      region: s3config.region,
+      endpoint: s3config.endpoint,
+      credentials: {
+        accessKeyId: s3config.accessKeyId,
+        secretAccessKey: s3config.secretAccessKey,
+      },
+    });
+  }
+
+  async run(): Promise<void> {
+    const servers = 
+  }
+
+  private async fetchObjectKeysForServer(serverId: string): Promise<string[]> {
+    const prefix = `servers/${serverId}/sounds/`;
+
+    const listCommand = new ListObjectsV2Command({
+      Bucket: this._bucketName,
+      Prefix: prefix,
+    });
+
+    let continuationToken: string | undefined;
+
+    const result = [];
+
+    do {
+      const response = await this._s3Client.send(listCommand);
+
+      const objectKeys = (response.Contents?.map((o) => o.Key).filter(
+        (key) => !!key
+      ) ?? []) as string[];
+
+      result.push(...objectKeys);
+
+      continuationToken = response.ContinuationToken;
+    } while (continuationToken);
+
+    return result;
+  }
+}

--- a/src/jobs/s3SynchronizationJob.ts
+++ b/src/jobs/s3SynchronizationJob.ts
@@ -1,7 +1,11 @@
 import { ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3";
-import { S3Config } from "../config.js";
+import { S3Config, soundboartConfig } from "../config.js";
 import fs from "fs";
+import { SoundObjectKey } from "../utils/s3.js";
+import { Paths } from "../utils/fsHelpers.js";
 const fsAsync = fs.promises;
+
+type SoundNamesGroupedByServers = Map<string, string[]>;
 
 export class S3SynchronizationJob {
   private _s3Client: S3Client;
@@ -21,11 +25,31 @@ export class S3SynchronizationJob {
   }
 
   async run(): Promise<void> {
-    const servers = 
+    const soundObjectKeys = await this.listSoundObjects();
+    const soundNamesGroupedByServerId =
+      await this.listSoundNamesGroupedByServer();
   }
 
-  private async fetchObjectKeysForServer(serverId: string): Promise<string[]> {
-    const prefix = `servers/${serverId}/sounds/`;
+  private async listSoundNamesGroupedByServer(): Promise<SoundNamesGroupedByServers> {
+    const serverIds = await fsAsync.readdir(soundboartConfig.soundsDirectory);
+
+    const soundNamesGroupedByServers = await Promise.all(
+      serverIds.map(async (serverId) => {
+        const soundNames = await fsAsync.readdir(
+          Paths.soundFilesDirectory(serverId)
+        );
+
+        return { serverId, soundNames };
+      })
+    );
+
+    return new Map(
+      soundNamesGroupedByServers.map((x) => [x.serverId, x.soundNames])
+    );
+  }
+
+  private async listSoundObjects(): Promise<SoundObjectKey[]> {
+    const prefix = "sounds/";
 
     const listCommand = new ListObjectsV2Command({
       Bucket: this._bucketName,
@@ -34,7 +58,7 @@ export class S3SynchronizationJob {
 
     let continuationToken: string | undefined;
 
-    const result = [];
+    const result: SoundObjectKey[] = [];
 
     do {
       const response = await this._s3Client.send(listCommand);
@@ -43,7 +67,13 @@ export class S3SynchronizationJob {
         (key) => !!key
       ) ?? []) as string[];
 
-      result.push(...objectKeys);
+      const soundObjectKeys = objectKeys
+        .map((objectKey) => SoundObjectKey.deserialize(objectKey))
+        .filter(
+          (soundObjectKey) => soundObjectKey !== null
+        ) as SoundObjectKey[];
+
+      result.push(...soundObjectKeys);
 
       continuationToken = response.ContinuationToken;
     } while (continuationToken);

--- a/src/jobs/s3SynchronizationJob.ts
+++ b/src/jobs/s3SynchronizationJob.ts
@@ -30,14 +30,13 @@ export class S3SynchronizationJob {
   }
 
   async run(): Promise<void> {
+    const startedAt = new Date();
+
     console.log("Starting S3 synchronization job.");
 
     const soundObjectKeys = await this.listSoundObjects();
     const soundNamesGroupedByServerId =
       await this.listSoundNamesGroupedByServer();
-
-    console.log("sounds grouped", soundNamesGroupedByServerId);
-    console.log("sound object keys", soundObjectKeys);
 
     const serverIds = new Set(
       soundObjectKeys
@@ -141,6 +140,10 @@ export class S3SynchronizationJob {
         console.log(`Uploaded file with key ${objectKey} to S3.`);
       });
     });
+
+    const elapsedTime = new Date().getTime() - startedAt.getTime();
+
+    console.log(`S3 synchronization finished. Elapsed time: ${elapsedTime}ms`);
   }
 
   private async listSoundNamesGroupedByServer(): Promise<SoundNamesGroupedByServers> {

--- a/src/jobs/s3SynchronizationJob.ts
+++ b/src/jobs/s3SynchronizationJob.ts
@@ -29,6 +29,11 @@ export class S3SynchronizationJob {
     const soundNamesGroupedByServerId =
       await this.listSoundNamesGroupedByServer();
 
+    const serverIds = new Set(
+      ...soundObjectKeys.map((objectKey) => objectKey.serverId),
+      ...soundNamesGroupedByServerId.keys()
+    );
+
     const findSoundsToDownloadForServer = (
       serverId: string
     ): SoundObjectKey[] => {
@@ -66,6 +71,13 @@ export class S3SynchronizationJob {
 
       return toUpload;
     };
+
+    serverIds.forEach(async (serverId) => {
+      const toDownload = await findSoundsToDownloadForServer(serverId);
+      const toUpload = await findSoundsToUploadForServer(serverId);
+
+      // TODO: Actually upload and download sounds
+    });
   }
 
   private async listSoundNamesGroupedByServer(): Promise<SoundNamesGroupedByServers> {

--- a/src/utils/s3.ts
+++ b/src/utils/s3.ts
@@ -11,6 +11,10 @@ export class SoundObjectKey {
     this.soundName = soundName;
   }
 
+  serialize(): string {
+    return `/sounds/${this.serverId}/${this.soundName}`;
+  }
+
   static deserialize(objectKey: string): SoundObjectKey | null {
     if (!soundObjectKeyPattern.test(objectKey)) return null;
 

--- a/src/utils/s3.ts
+++ b/src/utils/s3.ts
@@ -18,7 +18,9 @@ export class SoundObjectKey {
   static deserialize(objectKey: string): SoundObjectKey | null {
     if (!soundObjectKeyPattern.test(objectKey)) return null;
 
-    const [_, serverId, soundName] = objectKey.split("/");
+    console.log("key", objectKey);
+
+    const [_1, _2, serverId, soundName] = objectKey.split("/");
 
     return new SoundObjectKey(serverId, soundName);
   }

--- a/src/utils/s3.ts
+++ b/src/utils/s3.ts
@@ -1,0 +1,21 @@
+// The format of sound object keys in S3 is /sounds/<server-id>/<sound-name>
+
+const soundObjectKeyPattern = new RegExp(/\/sounds\/[^\/]+\/[^\/]+/);
+
+export class SoundObjectKey {
+  serverId: string;
+  soundName: string;
+
+  constructor(serverId: string, soundName: string) {
+    this.serverId = serverId;
+    this.soundName = soundName;
+  }
+
+  static deserialize(objectKey: string): SoundObjectKey | null {
+    if (!soundObjectKeyPattern.test(objectKey)) return null;
+
+    const [_, serverId, soundName] = objectKey.split("/");
+
+    return new SoundObjectKey(serverId, soundName);
+  }
+}

--- a/src/utils/s3.ts
+++ b/src/utils/s3.ts
@@ -18,8 +18,6 @@ export class SoundObjectKey {
   static deserialize(objectKey: string): SoundObjectKey | null {
     if (!soundObjectKeyPattern.test(objectKey)) return null;
 
-    console.log("key", objectKey);
-
     const [_1, _2, serverId, soundName] = objectKey.split("/");
 
     return new SoundObjectKey(serverId, soundName);


### PR DESCRIPTION
If S3 config is specified, a synchronization job now runs which figures out which files are in S3 and not on local disk, and vice versa, and uploads/downloads sound files to synchronize the two.
Startup will not complete until synchronization is finished.

This change means that the local disk can be treated more like a cache instead of as the actual storage layer, since everything should be backed up in object storage. 