### PR TITLE
Only leave voice channel when empty

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -64,6 +64,7 @@ import TranscribeSoundHandler from "./src/handlers/transcribeSoundHandler.js";
 import { ListSoundHistoryHandler } from "./src/handlers/listSoundHistoryHandler.js";
 import { getSettings } from "./src/serverSettings/settingsManager.js";
 import { getVoiceConnection } from "@discordjs/voice";
+import { clearVoiceChannelLeaveTimer } from "./src/utils/leaveChannelTimer.js";
 
 tracingSdk().start();
 
@@ -305,6 +306,8 @@ discordClient.on(
 
           if (connection) {
             connection.destroy();
+            clearVoiceChannelLeaveTimer(channel.guild.id);
+
             console.log(
               `Sound-boart channel with channelId='${channel.id}' in server with serverId='${channel.guildId}' after user with userId='${userId}' left the channel`
             );

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,7 +101,8 @@ const readSoundboartConfigFromEnv: () => SoundboartConfig = () => {
   const defaultPrefix = readEnvironmentVariable("DEFAULT_PREFIX");
 
   const leaveTimeoutSeconds =
-    readOptionalEnvironmentVariableAs<number>("LEAVE_TIMEOUT_SECONDS") ?? 300;
+    readOptionalEnvironmentVariableAs<number>("LEAVE_TIMEOUT_SECONDS") ??
+    60 * 60 * 6; // 6 hours
   const maxFileSizeInBytes =
     readOptionalEnvironmentVariableAs<number>("MAX_FILE_SIZE_IN_BYTES") ??
     5000000;

--- a/src/handlers/playGreetingSoundHandler.ts
+++ b/src/handlers/playGreetingSoundHandler.ts
@@ -1,7 +1,7 @@
 import ICommandHandler from "./commandHandler.js";
 import Discord from "discord.js";
 import { getSettings } from "../serverSettings/settingsManager.js";
-import { resetVoiceChannelTimer } from "../utils/leaveChannelTimer.js";
+import { resetVoiceChannelLeaveTimer } from "../utils/leaveChannelTimer.js";
 import { playSound } from "../utils/soundHelpers.js";
 import { Command } from "../command.js";
 import { Paths, fileOrDirectoryExists } from "../utils/fsHelpers.js";
@@ -63,7 +63,7 @@ class PlayGreetingSoundCommandHandler
     if (!soundExists) return;
 
     await playSound(soundFilePath, params.voiceChannel);
-    resetVoiceChannelTimer(params.voiceChannel.guildId);
+    resetVoiceChannelLeaveTimer(params.voiceChannel.guildId);
   }
 }
 

--- a/src/handlers/playRandomSoundHandler.ts
+++ b/src/handlers/playRandomSoundHandler.ts
@@ -1,7 +1,7 @@
 import ICommandHandler from "./commandHandler.js";
 import Discord from "discord.js";
 import { sendMessage } from "../utils/textChannelHelpers.js";
-import { resetVoiceChannelTimer } from "../utils/leaveChannelTimer.js";
+import { resetVoiceChannelLeaveTimer } from "../utils/leaveChannelTimer.js";
 import {
   playSound,
   getSoundNamesForServer,
@@ -114,7 +114,7 @@ class PlayRandomSoundCommandHandler
       );
     }
 
-    resetVoiceChannelTimer(voiceChannel.guildId);
+    resetVoiceChannelLeaveTimer(voiceChannel.guildId);
   }
 }
 

--- a/src/handlers/playSoundHandler.ts
+++ b/src/handlers/playSoundHandler.ts
@@ -1,7 +1,7 @@
 import ICommandHandler from "./commandHandler.js";
 import Discord from "discord.js";
 import { sendMessage } from "../utils/textChannelHelpers.js";
-import { resetVoiceChannelTimer } from "../utils/leaveChannelTimer.js";
+import { resetVoiceChannelLeaveTimer } from "../utils/leaveChannelTimer.js";
 import { getClosestSoundNames, playSound } from "../utils/soundHelpers.js";
 import { soundBoartEventEmitter } from "../soundBoartEventEmitter.js";
 import { soundPlayedEvent } from "../soundBoartEvents.js";
@@ -129,7 +129,7 @@ class PlaySoundCommandHandler implements ICommandHandler<Discord.Message> {
       }
     }
 
-    resetVoiceChannelTimer(voiceChannel.guildId);
+    resetVoiceChannelLeaveTimer(voiceChannel.guildId);
   }
 }
 

--- a/src/utils/leaveChannelTimer.ts
+++ b/src/utils/leaveChannelTimer.ts
@@ -11,7 +11,7 @@ export function clearVoiceChannelLeaveTimer(serverId: string) {
   delete timerMap[serverId];
 }
 
-export function resetVoiceChannelTimer(serverId: string) {
+export function resetVoiceChannelLeaveTimer(serverId: string) {
   if (timerMap[serverId]) {
     clearTimeout(timerMap[serverId]);
   }

--- a/src/utils/leaveChannelTimer.ts
+++ b/src/utils/leaveChannelTimer.ts
@@ -3,6 +3,14 @@ import { getVoiceConnection } from "@discordjs/voice";
 
 const timerMap: { [channelId: string]: NodeJS.Timeout } = {};
 
+export function clearVoiceChannelLeaveTimer(serverId: string) {
+  if (timerMap[serverId]) {
+    clearTimeout(timerMap[serverId]);
+  }
+
+  delete timerMap[serverId];
+}
+
 export function resetVoiceChannelTimer(serverId: string) {
   if (timerMap[serverId]) {
     clearTimeout(timerMap[serverId]);


### PR DESCRIPTION
Instead of leaving after a relatively short period of inactivity, listen for users leaving the voice channel, and leave if the bot is the last non-bot user left in the channel.